### PR TITLE
fix(chezmoiscripts): fix undefined $terrVersion in terraform install script

### DIFF
--- a/.chezmoiscripts/darwin/run_onchange_after_01_install_terraform.sh.tmpl
+++ b/.chezmoiscripts/darwin/run_onchange_after_01_install_terraform.sh.tmpl
@@ -3,11 +3,11 @@
 set -eufo pipefail
 
 
-{{- $terraformVersion := "1.15.5" }}
+{{- $terraformVersion := "1.15.6" }}
 if which mise > /dev/null; then
   echo "[!] The version manager for Terraform 'mise' - Found!"
   mise use --global terraform@{{ $terraformVersion }}
-  echo "[+] Successfully installed 'terraform' {{ $terrVersion }}."
+  echo "[+] Successfully installed 'terraform' {{ $terraformVersion }}."
   echo "{{ output "mise" "ls" "terraform" "-g" | trim }}."
 else
   echo "[!] The version manager for Terraform 'mise' - Not Found!"


### PR DESCRIPTION
## Summary
- `.chezmoiscripts/darwin/run_onchange_after_01_install_terraform.sh.tmpl` referenced an undefined template variable `$terrVersion`, which makes `chezmoi apply` fail on macOS with:
  ```
  chezmoi: template: ...: undefined variable "$terrVersion"
  ```
- Use the defined `$terraformVersion` variable instead.
- Bump the pinned Terraform version 1.15.5 → 1.15.6 (matches the currently installed version).

## Verification
`chezmoi execute-template < run_onchange_after_01_install_terraform.sh.tmpl` now renders successfully.