### PR TITLE
fix(mise): manage config.toml instead of unused config.yaml

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -1,0 +1,4 @@
+# Stale targets to remove from the home directory.
+
+# mise never reads YAML config; replaced by .config/mise/config.toml
+.config/mise/config.yaml

--- a/private_dot_config/private_mise/private_config.toml
+++ b/private_dot_config/private_mise/private_config.toml
@@ -1,4 +1,6 @@
 [tools]
+node = "26"
+ruby = "4.0.5"
 terraform = "latest"
 
 [tool_alias]
@@ -6,8 +8,3 @@ terraform = "asdf:mise-plugins/mise-hashicorp"
 
 [settings]
 idiomatic_version_file_enable_tools = ["deno", "node", "terraform", "packer"]
-
-
-# "_" is a special key for information you'd like to put into mise.toml that mise will never parse
-[_]
-foo = "bar"


### PR DESCRIPTION
## Summary
mise only loads `~/.config/mise/config.toml` — the chezmoi-managed `~/.config/mise/config.yaml` (TOML content under a `.yaml` filename) was never read. Verified with `mise config ls`, which lists only `config.toml`.

- Rename the source file to `private_config.toml` so chezmoi manages the file mise actually loads
- Declare `node = "26"` / `ruby = "4.0.5"` pins, matching what the darwin install scripts currently write into the live `config.toml` (keeps `chezmoi diff` clean)
- Drop the `[_] foo = "bar"` placeholder section
- Add `.chezmoiremove` so the stale `~/.config/mise/config.yaml` is cleaned up on apply

## Verification
`MISE_GLOBAL_CONFIG_FILE=<new file> mise config ls` parses the config and lists node, ruby, terraform.

## Note
Since the install scripts run `mise use --global`, they rewrite `config.toml`; if a future script pins a different version than declared here, `chezmoi diff` will show drift. A follow-up could replace the per-tool install scripts with a single `run_onchange` script that runs `mise install` against this declarative config.