### PR TITLE
fix(k9s): bump shellPod netshoot image to v0.15

### DIFF
--- a/private_dot_config/k9s/private_config.yaml
+++ b/private_dot_config/k9s/private_config.yaml
@@ -12,7 +12,7 @@ k9s:
     noIcons: false
     reactive: true
   shellPod:
-    image: nicolaka/netshoot:v0.11
+    image: nicolaka/netshoot:v0.15
     namespace: default
     limits:
       cpu: 100m


### PR DESCRIPTION
## Summary
- Update the k9s `shellPod` debug image `nicolaka/netshoot` from `v0.11` to `v0.15`, the latest published tag on Docker Hub (matches the current `latest` digest).