### PR TITLE
chore: clean up stale and duplicated config

### DIFF
--- a/.chezmoiscripts/darwin/run_onchange_after_02_configure_macos_defaults.sh
+++ b/.chezmoiscripts/darwin/run_onchange_after_02_configure_macos_defaults.sh
@@ -103,12 +103,6 @@ defaults write com.apple.appstore ShowDebugMenu -bool true
 defaults write com.apple.ActivityMonitor OpenMainWindow -bool true
 
 ###############################################################################
-# Clock                                                            #
-###############################################################################
-
-defaults write com.apple.menuextra.clock FlashDateSeparators -bool true
-
-###############################################################################
 # Keyboard
 ###############################################################################
 

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -6,7 +6,7 @@
 
 
 # Enable `direnv` hook
-which direnv > /dev/null \
+command -v direnv > /dev/null \
   && eval "$(direnv hook bash)"
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"


### PR DESCRIPTION
## Summary
- Remove the empty (0-byte) `.chezmoiexternal.yaml` — externals are defined in `.chezmoiexternals/github-release-assets.yaml`, so this file is dead weight.
- Remove the duplicated `Clock` section in the macOS defaults script; `FlashDateSeparators` is already set in the Menu Bar section above.
- Replace `which` with the POSIX-standard `command -v` in `.bashrc`.

All edited shell scripts pass `bash -n` syntax checks.